### PR TITLE
Close response body to avoid memory leaks

### DIFF
--- a/go.mustache
+++ b/go.mustache
@@ -101,6 +101,8 @@ func send{{{codeSlug}}}() {
 		fmt.Println("Failure : ", err)
 	}
 
+	defer resp.Body.Close()
+
 	// Read Response Body
 	respBody, _ := ioutil.ReadAll(resp.Body)
 


### PR DESCRIPTION
This ensures that the response body is closed when it's non-nil.